### PR TITLE
Fix PR 15 review findings and pin GitHub Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,14 +12,14 @@ jobs:
       contents: read
       deployments: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Use pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           version: 11.9.0
           run_install: false
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: pnpm
@@ -29,7 +29,7 @@ jobs:
       - name: Build
         run: pnpm run build
       - name: Deploy
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,14 +14,14 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Use pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           version: 11.9.0
           run_install: false
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: pnpm
@@ -30,6 +30,10 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Run lint
         run: pnpm run lint
+      - name: Semgrep guardrails
+        run: |
+          pipx install semgrep==1.151.0
+          semgrep --config .semgrep/ar-camera-and-dependencies.yml --error --metrics=off
       - name: Run svelte-check and tsc
         run: pnpm run check
       - name: Run tests

--- a/.semgrep/ar-camera-and-dependencies.yml
+++ b/.semgrep/ar-camera-and-dependencies.yml
@@ -10,10 +10,9 @@ rules:
         - /src/**/*.ts
       exclude:
         - /src/lib/ARScene.svelte
-    pattern-either:
-      - pattern: import("@ar-js-org/ar.js")
-      - pattern: import("aframe")
-      - pattern: from "aframe"
+    # Covers dynamic import(), static/side-effect import, from-clauses, and
+    # require(), with either quote style and package subpaths.
+    pattern-regex: '(?:import\s*\(\s*|from\s+|import\s+|require\s*\(\s*)["''](?:@ar-js-org/ar\.js|aframe)(?:/[^"'']*)?["'']'
 
   - id: ar-scene-import-without-camera-cleanup
     message: ARScene imports AR.js but does not call stopArJsCamera for media-track cleanup.
@@ -23,7 +22,7 @@ rules:
     paths:
       include:
         - /src/lib/ARScene.svelte
-    pattern-regex: 'import\("@ar-js-org/ar\.js"\)(?![\s\S]*stopArJsCamera\(\))'
+    pattern-regex: 'import\s*\(\s*["'']@ar-js-org/ar\.js["'']\s*\)(?![\s\S]*stopArJsCamera\(\))'
 
   - id: unsafe-three-bmfont-text-override
     message: Do not replace A-Frame's dmarcos three-bmfont-text fork with an arbitrary npm override.
@@ -35,12 +34,28 @@ rules:
         - /package.json
     pattern-regex: '"three-bmfont-text"\s*:\s*"(?!github:dmarcos/three-bmfont-text#)[^"]+"'
 
+  # Any git/tarball-hosted dependency outside the reviewed dmarcos
+  # three-bmfont-text fork (any commit) needs an explicit review — see
+  # DEPENDENCY_REVIEW.md. Keyed on the tarball URL rather than field order so
+  # entries with a leading integrity field are still caught.
   - id: unexpected-pnpm-git-hosted-dependency
-    message: pnpm git-hosted dependencies should be explicitly reviewed and documented.
+    message: pnpm git-hosted dependencies should be explicitly reviewed and documented in DEPENDENCY_REVIEW.md.
     severity: WARNING
     languages:
       - generic
     paths:
       include:
         - /pnpm-lock.yaml
-    pattern-regex: 'gitHosted: true, tarball: (?!https://codeload\.github\.com/dmarcos/three-bmfont-text/tar\.gz/eed4878795be9b3e38cf6aec6b903f56acd1f695)'
+    pattern-regex: 'tarball: (?!https://codeload\.github\.com/dmarcos/three-bmfont-text/tar\.gz/)'
+
+  # The toolchain is pnpm-only, but if an npm lockfile is ever regenerated it
+  # must not introduce unreviewed git-hosted dependencies either.
+  - id: unexpected-npm-git-hosted-dependency
+    message: npm git-hosted dependencies should be explicitly reviewed and documented in DEPENDENCY_REVIEW.md.
+    severity: WARNING
+    languages:
+      - generic
+    paths:
+      include:
+        - /package-lock.json
+    pattern-regex: '"resolved": "git\+(?!(?:ssh://git@|https://)github\.com/dmarcos/three-bmfont-text)'

--- a/DEPENDENCY_REVIEW.md
+++ b/DEPENDENCY_REVIEW.md
@@ -39,9 +39,24 @@ Socket flagged `aframe@1.7.1` because it depends on the dmarcos
 No npm override is applied for `three-bmfont-text`. Keeping A-Frame's declared
 fork is lower risk than replacing it with a different package that may be
 missing A-Frame-specific patches. The fork is listed as a direct dependency so
-the trust decision is explicit in `package.json`. `pnpm-workspace.yaml` sets
-`blockExoticSubdeps: false` because pnpm 11 otherwise rejects A-Frame's own
-declared dependency before the lockfile can be generated.
+the trust decision is explicit in `package.json`.
+
+### blockExoticSubdeps
+
+`pnpm-workspace.yaml` sets `blockExoticSubdeps: true`. pnpm 11 skips the
+exotic-subdependency check for resolutions that already come from the committed
+lockfile, so day-to-day `pnpm install` / `pnpm install --frozen-lockfile` pass
+while any *new* git/tarball-hosted transitive dependency is rejected at install
+time. The setting is boolean-only (no per-package allowlist), which means:
+
+- Bumping `aframe` (or anything else that re-resolves the fork at a new commit)
+  fails with `ERR_PNPM_EXOTIC_SUBDEP`. Temporarily set `blockExoticSubdeps:
+  false`, regenerate the lockfile, review the new git-hosted entries, and flip
+  it back to `true`. Treat that flip as the review checkpoint.
+- The semgrep rules in `.semgrep/ar-camera-and-dependencies.yml` (run in the
+  lint workflow) independently flag any lockfile entry whose tarball is not the
+  dmarcos `three-bmfont-text` fork, catching entries that enter via the
+  lockfile-skip path.
 
 Revisit this when A-Frame publishes a release that removes the GitHub
 dependency, or when the fork is published to an npm package that can be consumed

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,7 +4,11 @@ overrides:
   gl-matrix: 3.4.3
   got: 11.8.6
 
-blockExoticSubdeps: false
+# Exotic (git/tarball) subdeps stay blocked for fresh resolutions; entries
+# already in the committed lockfile (A-Frame's reviewed three-bmfont-text
+# fork) pass. Regenerating the lockfile after an aframe bump needs a
+# temporary flip to false — see DEPENDENCY_REVIEW.md.
+blockExoticSubdeps: true
 
 onlyBuiltDependencies:
   - '@biomejs/biome'

--- a/src/lib/ARScene.svelte
+++ b/src/lib/ARScene.svelte
@@ -68,7 +68,7 @@ const registerAFrameComponents = () => {
 <script lang="ts">
 import { onMount } from "svelte";
 import type { ARMode } from "./ar.ts";
-import { stopArJsCamera } from "./arCamera.ts";
+import { disarmArJsCameraWatch, stopArJsCamera } from "./arCamera.ts";
 
 const {
 	arMode,
@@ -86,6 +86,9 @@ let sceneEl: HTMLElement | null = $state(null);
 
 onMount(() => {
 	let cancelled = false;
+
+	// A watch armed by a previous teardown must not kill this scene's stream.
+	disarmArJsCameraWatch();
 
 	import("@ar-js-org/ar.js")
 		.then(() => {

--- a/src/lib/CourseCreator.svelte
+++ b/src/lib/CourseCreator.svelte
@@ -3,16 +3,17 @@ import { onDestroy, onMount } from "svelte";
 import { push } from "svelte-spa-router";
 import { encodeCourseShare, saveCustomCourse } from "./courses.ts";
 import { distanceMeters, formatDistance } from "./geo.ts";
+import {
+	getMapLibre,
+	loadMapLibre,
+	type MapLibreMap,
+	type MapLibreMarker,
+	type MapLibreModule,
+} from "./mapLibre.ts";
 import type { Course, Hole, LatLng } from "./types.ts";
 import { generateId } from "./utils.ts";
 
-type MapLibreModule = typeof import("maplibre-gl");
-type MapLibreMap = import("maplibre-gl").Map;
-type MapLibreMarker = import("maplibre-gl").Marker;
-
 let mapContainer: HTMLDivElement;
-let maplibregl: MapLibreModule | null = null;
-let maplibreLoad: Promise<MapLibreModule> | null = null;
 let map: MapLibreMap | null = null;
 let markers: MapLibreMarker[] = [];
 let watchId: number | null = null;
@@ -27,23 +28,6 @@ let shareCode: string | null = $state(null);
 let mapReady = $state(false);
 
 const canSave = $derived(holes.length > 0 && courseName.trim().length > 0);
-
-const loadMapLibre = async (): Promise<MapLibreModule> => {
-	if (maplibregl) return maplibregl;
-	maplibreLoad ??= Promise.all([
-		import("maplibre-gl"),
-		import("maplibre-gl/dist/maplibre-gl.css"),
-	])
-		.then(([module]) => {
-			maplibregl = module;
-			return module;
-		})
-		.catch((error) => {
-			maplibreLoad = null;
-			throw error;
-		});
-	return maplibreLoad;
-};
 
 const invalidateShareCode = (showStatus = true) => {
 	if (shareCode && showStatus) {
@@ -143,7 +127,7 @@ const refreshMarkers = () => {
 		marker.remove();
 	}
 	markers = [];
-	const maplibre = maplibregl;
+	const maplibre = getMapLibre();
 	if (!map || !maplibre) return;
 
 	holes.forEach((hole) => {

--- a/src/lib/MapGame.svelte
+++ b/src/lib/MapGame.svelte
@@ -21,6 +21,14 @@ import {
 	relativeBearing,
 } from "./geo.ts";
 import {
+	getMapLibre,
+	loadMapLibre,
+	type MapLibreGeoJsonSource,
+	type MapLibreMap,
+	type MapLibreMarker,
+	type MapLibreModule,
+} from "./mapLibre.ts";
+import {
 	compassHeading,
 	needsOrientationPermission,
 	nextUprightState,
@@ -29,11 +37,6 @@ import {
 import Scorecard from "./Scorecard.svelte";
 import type { GameSession, LatLng } from "./types.ts";
 import { acquireWakeLock } from "./wakeLock.ts";
-
-type MapLibreModule = typeof import("maplibre-gl");
-type MapLibreMap = import("maplibre-gl").Map;
-type MapLibreMarker = import("maplibre-gl").Marker;
-type MapLibreGeoJsonSource = import("maplibre-gl").GeoJSONSource;
 
 /** Arriving within this many meters of the basket counts as reaching it. */
 const BASKET_ARRIVAL_RADIUS_M = 10;
@@ -53,8 +56,6 @@ let session = $state(getInitialSession());
 let mapContainer: HTMLDivElement;
 let arrowAnchor: HTMLElement | null = $state(null);
 let arSceneEl: HTMLElement | null = $state(null);
-let maplibregl: MapLibreModule | null = null;
-let maplibreLoad: Promise<MapLibreModule> | null = null;
 let map: MapLibreMap | null = null;
 let userMarker: MapLibreMarker | null = null;
 let holeMarkers: MapLibreMarker[] = [];
@@ -69,6 +70,7 @@ let orientationHeading: number | null = $state(null);
 let gpsHeading: number | null = $state(null);
 let isDeviceUpright = $state(false);
 let arMode: ARMode | null = $state(null);
+let arSceneEnabled = $state(false);
 let cameraLoading = $state(true);
 let cameraError = $state(false);
 let locationError: string | null = $state(null);
@@ -96,23 +98,6 @@ const arrowRotation = $derived(
 		? relativeBearing(bearingDegrees(position, currentHole.basket), heading)
 		: null,
 );
-
-const loadMapLibre = async (): Promise<MapLibreModule> => {
-	if (maplibregl) return maplibregl;
-	maplibreLoad ??= Promise.all([
-		import("maplibre-gl"),
-		import("maplibre-gl/dist/maplibre-gl.css"),
-	])
-		.then(([module]) => {
-			maplibregl = module;
-			return module;
-		})
-		.catch((error) => {
-			maplibreLoad = null;
-			throw error;
-		});
-	return maplibreLoad;
-};
 
 const setArrowAnchor = (element: HTMLElement | null) => {
 	arrowAnchor = element;
@@ -178,7 +163,7 @@ const buildHoleMarkers = () => {
 		marker.remove();
 	}
 	holeMarkers = [];
-	const maplibre = maplibregl;
+	const maplibre = getMapLibre();
 	if (!map || !maplibre) return;
 
 	session.course.holes.forEach((hole, i) => {
@@ -482,6 +467,16 @@ $effect(() => {
 	document.body.classList.toggle("ar-video-visible", showAr);
 });
 
+// Keep AR.js/A-Frame out of the game chunk until the AR surface is needed,
+// then keep the scene mounted for the rest of the round: showAr flips on
+// every device tilt, and unmounting would tear down the camera stream and
+// force a slow AR.js re-init + getUserMedia on each raise of the phone.
+$effect(() => {
+	if ((showAr || arMode === "webxr") && !arSceneEnabled) {
+		arSceneEnabled = true;
+	}
+});
+
 // Aim the AR arrow at the basket as heading/position change
 $effect(() => {
 	if (arrowAnchor && arrowRotation !== null) {
@@ -546,6 +541,8 @@ onDestroy(() => {
 	clearLocationWatch();
 	map?.remove();
 	releaseWakeLock?.();
+	// Load-bearing even though ARScene cleans up after itself: a stream that
+	// AR.js attaches after ARScene already unmounted is only caught here.
 	stopArJsCamera();
 	document.body.style.overflow = "";
 });
@@ -599,7 +596,7 @@ onDestroy(() => {
 					</button>
 				</div>
 			{/if}
-			{#if arMode !== null && (showAr || arMode === "webxr")}
+			{#if arMode !== null && arSceneEnabled}
 				<ARScene {arMode} onArrowAnchor={setArrowAnchor} onScene={setArScene} />
 			{/if}
 			<div class="ar-hud">

--- a/src/lib/arCamera.test.ts
+++ b/src/lib/arCamera.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { disarmArJsCameraWatch, stopArJsCamera } from "./arCamera.ts";
+
+const makeStream = () => {
+	const stop = vi.fn();
+	return { stream: { getTracks: () => [{ stop }] }, stop };
+};
+
+// happy-dom's srcObject only accepts real MediaStream instances, so install
+// the fake as a plain data property instead.
+const attachStream = (video: HTMLVideoElement, stream: unknown) => {
+	Object.defineProperty(video, "srcObject", {
+		value: stream,
+		writable: true,
+		configurable: true,
+	});
+};
+
+const appendVideo = (id?: string, stream?: unknown) => {
+	const video = document.createElement("video");
+	if (id) video.id = id;
+	if (stream) attachStream(video, stream);
+	document.body.appendChild(video);
+	return video;
+};
+
+const nextTick = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+afterEach(() => {
+	disarmArJsCameraWatch();
+	document.body.innerHTML = "";
+	document.body.classList.remove("ar-video-visible");
+});
+
+describe("stopArJsCamera", () => {
+	it("stops tracks and removes the AR.js video plus the body class", () => {
+		const { stream, stop } = makeStream();
+		const video = appendVideo("arjs-video", stream);
+		document.body.classList.add("ar-video-visible");
+
+		stopArJsCamera();
+
+		expect(stop).toHaveBeenCalledOnce();
+		expect(video.isConnected).toBe(false);
+		expect(document.body.classList.contains("ar-video-visible")).toBe(false);
+	});
+
+	it("stops anonymous body-level videos that carry a media stream", () => {
+		const { stream, stop } = makeStream();
+		const video = appendVideo(undefined, stream);
+
+		stopArJsCamera();
+
+		expect(stop).toHaveBeenCalledOnce();
+		expect(video.isConnected).toBe(false);
+	});
+
+	it("catches a stream that AR.js attaches after cleanup already ran", async () => {
+		stopArJsCamera();
+
+		// Simulates getUserMedia resolving after the AR scene unmounted.
+		const { stream, stop } = makeStream();
+		const video = appendVideo("arjs-video", stream);
+		await nextTick();
+
+		expect(stop).toHaveBeenCalledOnce();
+		expect(video.isConnected).toBe(false);
+	});
+
+	it("leaves a new scene's video alone once the watch is disarmed", async () => {
+		stopArJsCamera();
+		disarmArJsCameraWatch();
+
+		const { stream, stop } = makeStream();
+		const video = appendVideo("arjs-video", stream);
+		await nextTick();
+
+		expect(stop).not.toHaveBeenCalled();
+		expect(video.isConnected).toBe(true);
+	});
+});

--- a/src/lib/arCamera.ts
+++ b/src/lib/arCamera.ts
@@ -8,7 +8,21 @@ const hasMediaTracks = (value: unknown): value is MediaStreamLike =>
 	"getTracks" in value &&
 	typeof (value as MediaStreamLike).getTracks === "function";
 
-export const stopArJsCamera = () => {
+let lateVideoWatch: MutationObserver | null = null;
+
+const stopVideo = (video: HTMLVideoElement) => {
+	if (hasMediaTracks(video.srcObject)) {
+		for (const track of video.srcObject.getTracks()) {
+			track.stop();
+		}
+	}
+
+	video.srcObject = null;
+	video.remove();
+};
+
+/** Stops and removes every AR.js-style video currently in the DOM. */
+const sweepArJsVideos = (): boolean => {
 	const candidates = new Set<HTMLVideoElement>();
 	const arjsVideo = document.getElementById("arjs-video");
 
@@ -25,15 +39,37 @@ export const stopArJsCamera = () => {
 	}
 
 	for (const video of candidates) {
-		if (hasMediaTracks(video.srcObject)) {
-			for (const track of video.srcObject.getTracks()) {
-				track.stop();
-			}
-		}
-
-		video.srcObject = null;
-		video.remove();
+		stopVideo(video);
 	}
 
+	return candidates.size > 0;
+};
+
+// AR.js only appends its <video> to <body> after getUserMedia resolves, which
+// can happen long after cleanup ran (e.g. the scene unmounted while the camera
+// permission prompt was still open). Watch for that late arrival and stop it,
+// or the camera stays live with nothing left to turn it off.
+const armLateVideoWatch = () => {
+	lateVideoWatch?.disconnect();
+	lateVideoWatch = new MutationObserver(() => {
+		if (sweepArJsVideos()) {
+			disarmArJsCameraWatch();
+		}
+	});
+	lateVideoWatch.observe(document.body, { childList: true });
+};
+
+/**
+ * Must be called before mounting an AR scene, so a watch armed by an earlier
+ * teardown doesn't kill the new scene's legitimate camera stream.
+ */
+export const disarmArJsCameraWatch = () => {
+	lateVideoWatch?.disconnect();
+	lateVideoWatch = null;
+};
+
+export const stopArJsCamera = () => {
+	sweepArJsVideos();
+	armLateVideoWatch();
 	document.body.classList.remove("ar-video-visible");
 };

--- a/src/lib/mapLibre.ts
+++ b/src/lib/mapLibre.ts
@@ -1,0 +1,28 @@
+export type MapLibreModule = typeof import("maplibre-gl");
+export type MapLibreMap = import("maplibre-gl").Map;
+export type MapLibreMarker = import("maplibre-gl").Marker;
+export type MapLibreGeoJsonSource = import("maplibre-gl").GeoJSONSource;
+
+let loaded: MapLibreModule | null = null;
+let loading: Promise<MapLibreModule> | null = null;
+
+export const loadMapLibre = async (): Promise<MapLibreModule> => {
+	if (loaded) return loaded;
+	loading ??= Promise.all([
+		import("maplibre-gl"),
+		import("maplibre-gl/dist/maplibre-gl.css"),
+	])
+		.then(([module]) => {
+			loaded = module;
+			return module;
+		})
+		.catch((error) => {
+			// Allow a retry after a transient load failure instead of caching it.
+			loading = null;
+			throw error;
+		});
+	return loading;
+};
+
+/** The loaded module, or null until loadMapLibre has resolved once. */
+export const getMapLibre = (): MapLibreModule | null => loaded;


### PR DESCRIPTION
## Summary

Fixes the six verified findings from the PR #15 review, plus pins GitHub Actions to commit SHAs.

- **ARScene remount churn**: restore the mount-once `arSceneEnabled` latch so `showAr` flips (device tilt, scorecard) only toggle visibility instead of destroying the a-scene and re-running AR.js init + `getUserMedia` on every raise of the phone.
- **Camera stream leak race**: `stopArJsCamera` now arms a `MutationObserver` on `<body>` that catches and stops a video AR.js attaches *after* cleanup ran (pending `getUserMedia`, e.g. an open permission prompt at route exit). `ARScene` disarms the watch on mount so a new scene's stream is never killed. Covered by new tests in `src/lib/arCamera.test.ts`.
- **Semgrep guardrail gaps**: the AR import rule is now quote- and form-agnostic (static/dynamic/`from`/`require`, single or double quotes — all previously-bypassing forms regression-tested); the pnpm lockfile rule keys on the tarball URL (immune to field ordering) and allowlists the dmarcos fork by repo; a companion rule covers `package-lock.json`'s `git+ssh`/`git+https` format; and semgrep now actually runs in the lint workflow (pinned to 1.151.0).
- **`blockExoticSubdeps`**: re-enabled (`true`). Lockfile-sourced resolutions pass, new exotic transitive deps are rejected at install time; `DEPENDENCY_REVIEW.md` documents the temporary-flip procedure for future aframe bumps.
- **`loadMapLibre` duplication**: extracted to a shared `src/lib/mapLibre.ts` with a true module-level singleton cache; both `MapGame` and `CourseCreator` now import it.
- Also includes the GitHub Actions SHA-pinning in `lint.yml` and `deploy.yml`.

## Validation

- `pnpm run lint`
- `pnpm run check`
- `pnpm run test` (63 passing, 4 new)
- `pnpm run build`
- `pnpm install --frozen-lockfile` (passes with `blockExoticSubdeps: true`)
- `semgrep --validate` + repo scan (0 findings) + bypass-form fixtures (all fire)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hbmartin/ar-disc-golf/pull/17?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-light.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->